### PR TITLE
Get default address URL from Info.plist (fixes #21)

### DIFF
--- a/WebViewScreenSaver/Info.plist
+++ b/WebViewScreenSaver/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>WVSSDefaultAddressURL</key>
+	<string>http://www.google.com/</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/WebViewScreenSaver/WVSSAddress.m
+++ b/WebViewScreenSaver/WVSSAddress.m
@@ -20,9 +20,10 @@
 //
 
 #import "WVSSAddress.h"
+#import "WebViewScreenSaverView.h"
 
 static NSTimeInterval const kDefaultDuration = 5 * 60.0;
-static NSString * const kScreenSaverDefaultURL = @"http://www.google.com/";
+static NSString * const kScreenSaverDefaultURLKey = @"WVSSDefaultAddressURL";
 
 // Keys for the dictionaries in kScreenSaverURLList - string values should not be changed.
 NSString * const kWVSSAddressURLKey = @"kScreenSaverURL";
@@ -38,11 +39,13 @@ NSString * const kWVSSAddressTimeKey = @"kScreenSaverTime";
 }
 
 + (WVSSAddress *)defaultAddress {
-  return [self addressWithURL:kScreenSaverDefaultURL duration:kDefaultDuration];
+  return [self addressWithURL:[self defaultAddressURL] duration:kDefaultDuration];
 }
 
 + (NSString *)defaultAddressURL {
-  return kScreenSaverDefaultURL;
+  // Get the default address from Info.plist
+  NSDictionary * info = [[NSBundle bundleForClass:[WebViewScreenSaverView class]] infoDictionary];
+  return [info valueForKey:kScreenSaverDefaultURLKey];
 }
 
 + (NSInteger)defaultDuration {


### PR DESCRIPTION
Instead of using a hard-coded default URL for new Address objects, read the default from Info.plist.

This would allow a user to tweak the Info.plist in the distribution package without needing to recompile (helpful when you want to deploy to multiple machines without a lot of manual configuration work).
